### PR TITLE
Capture stderr and stdout of git process

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,5 +29,13 @@ module.exports = function(repo, targetPath, opts, cb) {
             cb && cb(new Error("'git clone' failed with status " + status));
         }
     });
+    
+    process.stdout.on('data', function(data) {
+        console.log(data.toString());
+    });
+
+    process.stderr.on('data', function(data) {
+        console.error(data.toString());
+    });
 
 }


### PR DESCRIPTION
Currently, git-clone silently eats errors. That's bad, yo.