### PR TITLE
feat: add promise mode and other functions.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,49 +1,113 @@
-var spawn = require('child_process').spawn;
+var childProcess = require('child_process');
 
-module.exports = function(repo, targetPath, opts, cb) {
+var GITCLONE_PROCESS_HANDLED_EVENTS = ['disconnect', 'error', 'exit', 'message', 'channel'];
+// Wrap off differences between sync processes and async ones.
+function processOn(process, sync, event, listener) {
+	if (!sync) {
+		process.on(event, listener);
+	} else {
+		switch (event) {
+			case 'exit':
+			case 'close':
+				listener && listener(process.status, process.signal);
+				break;
+			case 'disconnect':
+				listener && listener();
+				break;
+			case 'error':
+				listener && listener(process.error);
+				break;
+			case 'message':
+			case 'channel':
+				// event type omitted.
+				break;
+		}
+	}
+}
 
-    if (typeof opts === 'function') {
-        cb = opts;
-        opts = null;
-    }
+/**
+ *
+ * @param {string} repo repo's clone path
+ * @param {string} targetPath save path
+ * @param {Object} opts options
+ * @param {function} cb callback function
+ * @param {function} el event listener, $0 process, $1 event, $2 & $3 callback params.
+ * @return {promise}
+ */
+module.exports = function (repo, targetPath, opts, cb, el) {
 
-    opts = opts || {};
+	if (typeof opts === 'function') {
+		el = cb;
+		cb = opts;
+		opts = null;
+	}
 
-    var git = opts.git || 'git';
-    var args = ['clone'];
+	opts = opts || {};
+	// get spawn method.
+	var isSync = opts.sync;
+	var spawn = opts.sync ? childProcess.spawnSync : childProcess.spawn;
+	var git = opts.git || 'git';
+	var args = ['clone'];
+	// Make it able to add user defined arguments.
+	// checking user defined args whether being conflict with default ones.
+	var userDefinedArgs = opts.args || [];
 
-    if (opts.shallow) {
-        args.push('--depth');
-        args.push('1');
-    }
+	if (opts.shallow) {
+		if (userDefinedArgs.find(_ => v.trim() === '--depth')) {
+			reject(new Error("You cannot specify `--depth` by yourself when shallow is set `true`"));
+			return;
+		}
+		args.push('--depth');
+		args.push('1');
+	}
+	args.push('--');
+	args.push(repo);
+	args.push(targetPath);
 
-    args.push('--');
-    args.push(repo);
-    args.push(targetPath);
+	if (opts.progress) {
+		args.push('--progress');
+	}
+	args = args.concat(userDefinedArgs);
 
-    var process = spawn(git, args);
-    process.on('close', function(status) {
-        if (status == 0) {
-            if (opts.checkout) {
-                _checkout();
-            } else {
-                cb && cb();    
-            }
-        } else {
-            cb && cb(new Error("'git clone' failed with status " + status));
-        }
-    });
+	var process = spawn(git, args);
+	// Add listener.
+	GITCLONE_PROCESS_HANDLED_EVENTS.forEach(event => {
+		processOn(process, isSync, event, function (process, par0, par1) {
+			el && el(process, event, par0, par1);
+		});
+	})
 
-    function _checkout() {
-        var args = ['checkout', opts.checkout];
-        var process = spawn(git, args, { cwd: targetPath });
-        process.on('close', function(status) {
-            if (status == 0) {
-                cb && cb();
-            } else {
-                cb && cb(new Error("'git checkout' failed with status " + status));
-            }
-        });
-    }
+	function resultHandling(resolve, reject) {
+		processOn(process, isSync, 'close', function (status) {
+			if (status == 0) {
+				if (opts.checkout) {
+					_checkout();
+				} else {
+					resolve();
+				}
+			} else {
+				reject(new Error("'git clone' failed with status " + status));
+			}
+		})
+		function _checkout() {
+			var args = ['checkout', opts.checkout];
+			var coProcess = spawn(git, args, { cwd: targetPath });
+			processOn(coProcess, isSync, 'close', function (status) {
+				if (status == 0) {
+					resolve();
+				} else {
+					reject(new Error("'git checkout' failed with status " + status));
+				}
+			});
+		}
+	}
 
+	if (opts.promise) {
+		if (typeof Promise === 'undefined') {
+			throw new Error("[git-clone] <error>: Promise not supported. You cannot use promise.");
+		}
+		return new Promise(resultHandling);
+	} else {
+		resultHandling(cb, cb);
+	}
 }


### PR DESCRIPTION
```javascript
// option's been extended.
opts: {
  sync: true, // for sync usage.
  promise: true, // if set, return a promise object.
  args: ['-b', 'tags/0.0.1'], // for user defined arguments.
  progress: true, // if set, add '--progress' flag.
}
```
event listener's been added.

```
/**
 *
 * @param {string} repo repo's clone path
 * @param {string} targetPath save path
 * @param {Object} opts options
 * @param {function} cb callback function
 * @param {function} el event listener, $0 process, $1 event, $2 & $3 callback params.
 * @return {promise}
 */
module.exports = function (repo, targetPath, opts, cb, el)
```
